### PR TITLE
configure default locale in javadoc-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,9 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <version>3.3.1</version>
+            <configuration>
+               <locale>en</locale>
+            </configuration>
             <executions>
                <execution>
                   <id>generate-javadoc</id>


### PR DESCRIPTION
Co-authored-by: greek-zzf <aaaa159557190@gmail.com>

@greek-zzf 感谢贡献代码。

抱歉没有及时合并。原因是这些仓库其实并不是一个个手工创建管理的，是使用一个自动化系统生成和管理的，我花了一点时间让这个系统能够接受PR。

之前的PR https://github.com/ByteLegendQuest/java-write-javadoc/pull/9 的提交历史看起来有点奇怪是因为`dev`分支落后`master`分支太多，我把你的提交cherrypick到这个PR里来了。

另外，你本地的git似乎没有配置正确的邮箱，所以 https://github.com/ByteLegendQuest/java-write-javadoc/pull/9/commits/44586ddc24ecc5b7b496655076f75d172bcad620 里显示的是奇怪的用户。我在这个PR里改过来了。